### PR TITLE
Fixing UTEST directory breaking getlog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ CS1_UTEST_DIR="cs1_utest" # as defined in SpaceDecl.h
 # ENV : either CS1_UTEST for test environment or empty for PROD, perform a 'make clean' when changing this parameter
 #
 UTEST_ENV=-DCS1_UTEST $(MEM_LEAK_MACRO) $(CPPUTEST_LIBS) 
-ENV = -DCS1_DEBUG  $(UTEST_ENV)  -DPRESERVE
+ENV = -DCS1_DEBUG  -DPRESERVE
 
 
 #
@@ -90,7 +90,8 @@ $(SPACE_COMMANDER_BIN)/%.o: src/space-commander/%.cpp include/space-commander/%.
 $(SPACE_COMMANDER_BIN): src/space-commander/space-commander-main.cpp $(COMMON_OBJECTS) $(OBJECTS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) $(INCLUDES) $(LIBPATH) -o $@/space-commander $^ $(LIBS) $(ENV)
 
-test: make_dir bin/AllTests $(SPACE_COMMANDER_BIN)
+test: ENV = -DCS1_DEBUG  $(UTEST_ENV)  -DPRESERVE
+test: buildBin make_dir bin/AllTests $(SPACE_COMMANDER_BIN)
 	mkdir -p $(CS1_UTEST_DIR)
 
 bin/AllTests: tests/unit/AllTests.cpp  $(UNIT_TEST) $(COMMON_OBJECTS) $(OBJECTS) 

--- a/csmake.sh
+++ b/csmake.sh
@@ -114,15 +114,17 @@ fi
 # Build x86 
 #
 #------------------------------------------------------------------------------
-echo ""
-echo "=== Build x86 ==="
-make buildBin 
+if [ $SKIP_TEST -eq 1 ]; then
+    echo ""
+    echo "=== Build x86 ==="
+    make buildBin 
 
-if [ $? -ne 0 ]; then
-    echo -e "\e[31m Build x86 failed\e[0m"
-    exit -1
-else
-    echo -e "\e[32m Build x86 success!\e[0m"
+    if [ $? -ne 0 ]; then
+        echo -e "\e[31m Build x86 failed\e[0m"
+        exit -1
+    else
+        echo -e "\e[32m Build x86 success!\e[0m"
+    fi
 fi
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Changing the build targets slightly. "test" target will set the utest flag and rebuild the commander. "buildBin" will not have the flag set and will build the commander without tests. csmake.sh had to be modified, only running buildBin if SKIP_TEST=1